### PR TITLE
Replace expand-region dependency with puni

### DIFF
--- a/change-inner.el
+++ b/change-inner.el
@@ -8,7 +8,7 @@
 ;; Version: 0.3.0
 ;; URL: https://github.com/slotThe/change-inner
 ;; Keywords: convenience, extensions
-;; Package-Requires: ((expand-region "0.7"))
+;; Package-Requires: ((puni "0"))
 
 ;; This file is NOT part of GNU Emacs.
 ;;


### PR DESCRIPTION
Hello!

Thank you for that package! It is really, really helpful. 

I've noticed that even though this package doesn't use `expand-region` anymore it still pulls it as a dependency. This PR should fix that. I've also added `puni` there.